### PR TITLE
feat: use status.mapswipe.org for status page domain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,23 +8,31 @@ repos:
       - id: check-case-conflict
       - id: detect-private-key
 
-  # TODO: Check if terragrunt init is run?
-  - repo: https://github.com/gruntwork-io/pre-commit
-    rev: "v0.1.30"  # Check for latest: https://github.com/gruntwork-io/pre-commit/releases
-    hooks:
-      - id: tofu-fmt
-      - id: tofu-validate
-      - id: tflint
-        pass_filenames: false
-        always_run: true
-      - id: terragrunt-hcl-fmt
-
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: "v1.98.0"
+    rev: "v1.105.0"
     hooks:
+      - id: terragrunt_fmt
+      - id: terraform_fmt
+        args:
+         - --hook-config=--tf-path=tofu
+      - id: terraform_tflint
+        args:
+         - --hook-config=--tf-path=tofu
+      - id: terraform_validate
+        args:
+         - --hook-config=--tf-path=tofu
+      - id: terragrunt_providers_lock
+        args:
+          - --hook-config=--tf-path=tofu
+          - --hook-config=--mode=regenerate-lockfile-if-some-platform-missed
+          - --args=-platform=darwin_arm64
+          - --args=-platform=darwin_amd64
+          - --args=-platform=linux_amd64
       - id: terraform_providers_lock
         args:
+          - --hook-config=--mode=always-regenerate-lockfile
           - --hook-config=--mode=regenerate-lockfile-if-some-platform-missed
           - --hook-config=--tf-path=tofu
+          - --args=-platform=darwin_arm64
           - --args=-platform=darwin_amd64
           - --args=-platform=linux_amd64

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.opentofu.org/uptimerobot/uptimerobot" {
   constraints = "~> 1.3.9"
   hashes = [
     "h1:XsCoACIlheJ4Kqa4KeCbxdxtmJeH9El008yEVMaNp/U=",
+    "h1:o031cHi6GLIz3Y4EkxRPl8YZB6aICiaBA4mSFAnatGA=",
     "h1:plNfrpSnq8Di7fTHE7Q8tkMdGLGds6dOEGIolwk5d+M=",
     "zh:291117f52005e6a76eb349bf168213ec2581150f5c4f25675c087790ee6340d9",
     "zh:662d943299d59c21197a1e4449d64fb78ecb6cb71b0fe91db2aaf058d14a0e45",

--- a/terraform/modules/cron_monitor/.terraform.lock.hcl
+++ b/terraform/modules/cron_monitor/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.opentofu.org/uptimerobot/uptimerobot" {
   constraints = "~> 1.3.9"
   hashes = [
     "h1:XsCoACIlheJ4Kqa4KeCbxdxtmJeH9El008yEVMaNp/U=",
+    "h1:o031cHi6GLIz3Y4EkxRPl8YZB6aICiaBA4mSFAnatGA=",
     "h1:plNfrpSnq8Di7fTHE7Q8tkMdGLGds6dOEGIolwk5d+M=",
     "zh:291117f52005e6a76eb349bf168213ec2581150f5c4f25675c087790ee6340d9",
     "zh:662d943299d59c21197a1e4449d64fb78ecb6cb71b0fe91db2aaf058d14a0e45",

--- a/terraform/modules/http_monitor/.terraform.lock.hcl
+++ b/terraform/modules/http_monitor/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.opentofu.org/uptimerobot/uptimerobot" {
   constraints = "~> 1.3.9"
   hashes = [
     "h1:XsCoACIlheJ4Kqa4KeCbxdxtmJeH9El008yEVMaNp/U=",
+    "h1:o031cHi6GLIz3Y4EkxRPl8YZB6aICiaBA4mSFAnatGA=",
     "h1:plNfrpSnq8Di7fTHE7Q8tkMdGLGds6dOEGIolwk5d+M=",
     "zh:291117f52005e6a76eb349bf168213ec2581150f5c4f25675c087790ee6340d9",
     "zh:662d943299d59c21197a1e4449d64fb78ecb6cb71b0fe91db2aaf058d14a0e45",

--- a/terraform/status_pages.tf
+++ b/terraform/status_pages.tf
@@ -1,5 +1,6 @@
 resource "uptimerobot_psp" "global" {
-  name = "MapSwipe - Uptime"
+  name          = "MapSwipe - Uptime"
+  custom_domain = "status.mapswipe.org"
 
   custom_settings = {
     page = {

--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -1,5 +1,6 @@
 # Generate provider configuration AND required_providers block
 locals {
+  # https://registry.terraform.io/providers/uptimerobot/uptimerobot/
   uptimerobot_provider_contents = <<EOF
 terraform {
   required_version = ">= 1.11.0"


### PR DESCRIPTION
Addresses
- Custom domain

## Changes

* Use https://status.mapswipe.org for status page
* Use pre-commit to mutate the fix
* Add hook for `Check if terragrunt init is run?` with `terragrunt_providers_lock`

## This PR doesn't introduce any:

- [x] Redundant monitor names
- [x] Inconsistent namings
- [x] TODO comments

## This PR contains valid:

- [x] Monitors
- [x] Naming conventions (prod and stage)